### PR TITLE
Fix type signature in exercise 1.4-i prompt

### DIFF
--- a/algebra.tex
+++ b/algebra.tex
@@ -319,8 +319,8 @@ with other programming languages.
 
 \begin{exercise}
 Use Curry--Howard to prove the exponent law that $a^b \times a^c =
-a^{b+c}$. That is, provide a function of the type \ty{(b -> a) -> (c -> a) ->
-Either b c -> a} and one of \ty{(Either b c -> a) -> (b -> a, c -> a)}.
+a^{b+c}$. That is, provide a function of the type \ty{(b -> a, c -> a) ->
+(Either b c -> a)} and one of \ty{(Either b c -> a) -> (b -> a, c -> a)}.
 \end{exercise}
 \begin{solution}
 \unspacedSnip{Algebra}{productRule1To}


### PR DESCRIPTION
I'm fairly new to this material so I'm not 100% sure if this is correct. This PR addresses two issues if so:

1. Make the parenthesis style of each function consistent (directly matching the example of `to` and `from` for isomorphisms).
2. `(b -> a) -> (c -> a)` should be a pair/product type, not a function/exponential type — corrected to `(b -> a, c -> a)`.

Enjoying the sample PDF so far!