### PR TITLE
s/values/types

### DIFF
--- a/singletons.tex
+++ b/singletons.tex
@@ -34,7 +34,7 @@ families, and data kinds, among others.
 
 Dependent types in Haskell can be approximated via
 \defnn{singletons}{singleton}, which are to be understood as an \gls{isomorphism}
-between terms and values.
+between terms and types.
 
 Consider the unit type \ty{()}, whose only inhabitant is the unit value \hs{()}.
 This type has an interesting property; if you know a value's type is unit, you


### PR DESCRIPTION
> Dependent types in Haskell can be approximated
via singletons, which are to be understood as an
isomorphism between terms and **values**.

I think "terms and **types**" was meant here.

P.S. Thank you so much for this book, it's amazingly well written!