### PR TITLE
Update GADTs.hs to include FlexibleInstances extension

### DIFF
--- a/code/GADTs.hs
+++ b/code/GADTs.hs
@@ -1,6 +1,7 @@
 -- # pragmas
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}


### PR DESCRIPTION
Thank you for the excellent book!!!  🙌 

In the `HList` section of Chapter 5, `FlexibleInstances` is needed for the first iteration of defining instances for `HList`, like these `Eq` ones:

```haskell
instance Eq (HList '[]) where
  HNil == HNil = True

instance (Eq t, Eq (HList ts)) => Eq (HList (t ': ts)) where
  (a :# as) == (b :# bs) = a == b && as == bs
```

The first iteration of the instances is commented out in `GADTs.hs`, but for readers following/typing along with the book, will need to enable `FlexibleInstances` for the code to build.