### PR TITLE
Added note about first-class-families

### DIFF
--- a/extensible-data.tex
+++ b/extensible-data.tex
@@ -55,6 +55,8 @@ through them first, and use their lessons to help build open products.
 
 \preamble{OpenSum}
 
+Note: for the code examples in this section to work you will need to have \pkg{first-class-families}\cite{fcf} installed
+
 By definition, an open sum is a container of a data whose type isn't known
 statically. Furthermore, there are no guarantees that we know which types it
 \emph{might be,} since the list of types itself might be polymorphic.


### PR DESCRIPTION
Solves [this issue](https://github.com/isovector/thinking-with-types/issues/18), which wasn't really an issue, but makes it more explicit that `first-class-families` need to be installed in the project for the code samples to work.